### PR TITLE
Track volumes

### DIFF
--- a/driver/store/bolt/bolt.go
+++ b/driver/store/bolt/bolt.go
@@ -1,0 +1,98 @@
+package bolt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.etcd.io/bbolt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const bucketName = "csi.kunde21.moosefs"
+
+type VolStore struct {
+	bdb    *bbolt.DB
+	bucket []byte
+}
+
+type Volume struct {
+	ID       string
+	Capacity int64
+	Params   map[string]string
+}
+
+// New volume storage
+func New(fname string) (*VolStore, error) {
+	bdb, err := bbolt.Open(fname, 0744, &bbolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tracking store: %w", err)
+	}
+
+	if err := bdb.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+		if err != nil {
+			return err
+		}
+		stats := b.Stats()
+		fmt.Println("tracking store:", stats)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to initialize tracking store: %w", err)
+	}
+	return &VolStore{
+		bdb:    bdb,
+		bucket: []byte(bucketName),
+	}, nil
+}
+
+// Close the store and release resources.
+func (vs *VolStore) Close() error {
+	return vs.bdb.Close()
+}
+
+// GetVolume fetches the volume, if it exists.
+func (vs *VolStore) GetVolume(ctx context.Context, id string) (*Volume, error) {
+	var v *Volume
+	return v, vs.bdb.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(vs.bucket)
+		vol := b.Get([]byte(id))
+		if vol == nil {
+			return status.Errorf(codes.NotFound, "volume %q does not exist", id)
+		}
+		return json.Unmarshal(vol, &v)
+	})
+}
+
+// InsertVolume registers a new volume.
+// Noop if the same volume is already registered.
+func (vs *VolStore) InsertVolume(ctx context.Context, vol Volume) error {
+	if vol.ID == "" {
+		return fmt.Errorf("misssing volume ID")
+	}
+	v, err := json.Marshal(vol)
+	if err != nil {
+		return fmt.Errorf("invalid json: %w", err)
+	}
+	return vs.bdb.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(vs.bucket)
+		svol := b.Get([]byte(vol.ID))
+		if svol != nil && !bytes.Equal(v, svol) {
+			return status.Error(codes.AlreadyExists, "volume exists")
+		}
+		return b.Put([]byte(vol.ID), v)
+	})
+}
+
+// DeleteVolume unregisters the volume, if it exists (noop if it doesn't).
+func (vs *VolStore) DeleteVolume(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("misssing volume ID")
+	}
+	return vs.bdb.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(vs.bucket).Delete([]byte(id))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
+	go.etcd.io/bbolt v1.3.2
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	google.golang.org/grpc v1.30.0
 	k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/kubernetes/moosefs-csi-plugin.yaml
+++ b/kubernetes/moosefs-csi-plugin.yaml
@@ -63,6 +63,11 @@ spec:
         #       mountPath: /var/lib/csi/sockets/pluginproxy/
         # Moosefs Plugin
         - name: moosefs-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
           image: kunde21/moosefs-csi:v0.0.5
           args :
             - "controller"
@@ -70,6 +75,10 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--server=$(MFS_SERVER)"           
             - "--root=$(MFS_ROOT_PATH)"
+            - "--mount=$(MFS_ROOT_MOUNT_PATH)"
+          envFrom:
+            - configMapRef:
+                name: csi-moosefs-config
           env:
             - name: NODE_ID
               valueFrom:
@@ -77,17 +86,22 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: MFS_ROOT_PATH
-              value: "/kubernetes/"
-            - name: MFS_SERVER
-              value: "mfsmaster" # IP address of your MooseFS master
+            - name: MFS_ROOT_MOUNT_PATH
+              value: /var/lib/mfs/kubernetes
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: pods-mount-dir
+              mountPath: /var/lib/mfs/kubernetes
+              mountPropagation: "Bidirectional"
       volumes:
         - name: socket-dir
           emptyDir: {}
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/mfs/kubernetes
+            type: DirectoryOrCreate
 
 ---
 kind: DaemonSet
@@ -143,6 +157,9 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--server=$(MFS_SERVER)"           
             - "--root=$(MFS_ROOT_PATH)"
+          envFrom:
+            - configMapRef:
+                name: csi-moosefs-config
           env:
             - name: NODE_ID
               valueFrom:
@@ -150,10 +167,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            - name: MFS_ROOT_PATH
-              value: "/kubernetes/"
-            - name: MFS_SERVER
-              value: "mfsmaster" # IP address of your MooseFS master
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: plugin-dir

--- a/moosefs-csi/cmd/controller.go
+++ b/moosefs-csi/cmd/controller.go
@@ -41,14 +41,19 @@ to quickly create a Cobra application.`,
 	RunE: RunController,
 }
 
-var root string
-
-func init() { rootCmd.AddCommand(controllerCmd) }
+func init() {
+	rootCmd.AddCommand(controllerCmd)
+	controllerCmd.Flags().StringVarP(&csiArgs.mountDir, "mount", "m", "/opt/mfs/kubernetes",
+		"mount point for controller directory.")
+}
 
 // RunController runs the controller server
 func RunController(cmd *cobra.Command, args []string) error {
 	driver := mfs.NewMFSdriver(csiArgs.nodeID, csiArgs.endpoint, csiArgs.server)
-	cs := mfs.NewControllerServer(driver)
+	cs, err := mfs.NewControllerServer(driver, csiArgs.root, csiArgs.mountDir)
+	if err != nil {
+		return err
+	}
 	is, err := mfs.NewIdentityServer(driver)
 	if err != nil {
 		return err

--- a/moosefs-csi/cmd/root.go
+++ b/moosefs-csi/cmd/root.go
@@ -27,7 +27,7 @@ import (
 var (
 	cfgFile string
 	csiArgs struct {
-		endpoint, server, nodeID, root string
+		endpoint, server, nodeID, root, mountDir string
 	}
 )
 

--- a/moosefs-csi/main_test.go
+++ b/moosefs-csi/main_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestSanity(t *testing.T) {
 	const testdir = "/tmp/csitesting"
+	const root = "/csitest"
+	const conDir = "/tmp/controller"
 	mfsEP := os.Getenv("MOOSEFS_ENDPOINT")
 	if mfsEP == "" {
 		t.Skipf("missing %q environment variable, skipping csi-sanity test", "MOOSEFS_ENDPOINT")
@@ -41,8 +43,11 @@ func TestSanity(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ns := mfs.NewNodeServer(driver, m, "/testing/")
-	cs := mfs.NewControllerServer(driver)
+	ns := mfs.NewNodeServer(driver, m, root)
+	cs, err := mfs.NewControllerServer(driver, root, conDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ids, err := mfs.NewIdentityServer(driver)
 	if err != nil {
 		t.Fatal(err)
@@ -52,6 +57,7 @@ func TestSanity(t *testing.T) {
 			t.Log(err)
 		}
 	}()
+	t.Cleanup(func() { cs.Close() })
 
 	conf := sanity.NewTestConfig()
 	conf.Address = ep


### PR DESCRIPTION
Utilized a simple boltdb storage to track the creation and deletion of dynamic volumes.  Can be extended to track all volumes with the addition of the controller publish/unpublish capabilities, in the future.

Completes the spec implementation and passes csi sanity check testing.