### PR TITLE
Use ClusterFirstWithHostNet for DNS

### DIFF
--- a/kubernetes/moosefs-csi-plugin.yaml
+++ b/kubernetes/moosefs-csi-plugin.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: csi-moosefs-plugin-controller
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         # Moosefs Plugin
         - name: moosefs-csi-plugin
@@ -27,8 +28,8 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: kunde21/moosefs-csi
-          args :
+          image: kunde21/moosefs-csi:v3.0.116-v0.1.1
+          args:
             - "controller"
             - "--node=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -47,7 +48,7 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: MFS_ROOT_MOUNT_PATH
               value: /opt/mfs/kubernetes
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -59,34 +60,34 @@ spec:
               mountPropagation: "Bidirectional"
         # provisioner
         - name: csi-provisioner
-          image: kunde21/k8s-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
           args:
-            - "--provisioner=csi.kunde21.moosefs"
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/      
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         # attacher
         - name: csi-attacher
-          image: kunde21/k8s-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         # resizer
         - name: csi-resizer
-          image: kunde21/k8s-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--timeout=15s"
             - "--csi-address=$(ADDRESS)"
@@ -94,7 +95,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -143,19 +144,20 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: csi-moosefs-plugin-node
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: csi-moosefs-plugin 
+        - name: csi-moosefs-plugin
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: kunde21/moosefs-csi
-          args :
+          image: kunde21/moosefs-csi:v3.0.116-v0.1.1
+          args:
             - "node"
             - "--node=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--server=$(MFS_SERVER)"           
+            - "--server=$(MFS_SERVER)"
             - "--root=$(MFS_ROOT_PATH)"
           envFrom:
             - configMapRef:
@@ -172,13 +174,13 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: device-dir
         - name: driver-registrar
-          image: kunde21/k8s-node-driver-registrar:v1.3.0
-          imagePullPolicy: "IfNotPresent"
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          imagePullPolicy: IfNotPresent
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -208,10 +210,8 @@ spec:
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: /var/lib/kubelet/pods
             type: Directory
         - name: device-dir
           hostPath:
             path: /dev
-
-...

--- a/kubernetes/moosefs-csi-rbac.yaml
+++ b/kubernetes/moosefs-csi-rbac.yaml
@@ -65,6 +65,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
@@ -76,7 +79,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
-    verbs:  ["get", "list", "create", "delete"]
+    verbs: ["get", "list", "create", "delete"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Functional changes:
* Use `dnsPolicy: ClusterFirstWithHostNet`. This enables the plugin to consume a MFS leader hosted on the K8S cluster, e.g. `leader.moosefs.svc.cluster.local`. Currently, we can only consume leaders hosted on bare metal.

Housekeeping:
* Adds an explicit `v3.0.116-v0.1.1` tag to images -- otherwise containers would crash due to the absence of a `latest` tag.
* Modifies CSI containers to use official (+multi-platform) sig-storage images.
* Modifies RBAC to include `volumeattachments/status`.